### PR TITLE
Fix compilation errors

### DIFF
--- a/bindings/lua/luars232.c
+++ b/bindings/lua/luars232.c
@@ -530,6 +530,7 @@ static void create_metatables(lua_State *L, const char *name, const luaL_reg *me
 #endif
 }
 
+RS232_LIB int luaopen_luars232(lua_State *L);
 RS232_LIB int luaopen_luars232(lua_State *L)
 {
 	int i;
@@ -564,6 +565,7 @@ RS232_LIB int luaopen_luars232(lua_State *L)
 	return 1;
 }
 
+RS232_LIB int luaopen_rs232_core(lua_State *L);
 RS232_LIB int luaopen_rs232_core(lua_State *L){
 	return luaopen_luars232(L);
 }


### PR DESCRIPTION
Fixes the following error:
uars232.c:533:15: error: no previous prototype for 'luaopen_luars232' [-Werror=missing-prototypes]
  533 | RS232_LIB int luaopen_luars232(lua_State *L)
      |               ^~~~~~~~~~~~~~~~
luars232.c:567:15: error: no previous prototype for 'luaopen_rs232_core' [-Werror=missing-prototypes]
  567 | RS232_LIB int luaopen_rs232_core(lua_State *L){
      |               ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

The regression has been introduced by: https://github.com/srdgame/librs232/commit/89aa0140a26dc7dad2e786cfe08877c7094622f4