### PR TITLE
Lua 5.4 in rockspec

### DIFF
--- a/bindings/lua/rs232.lua
+++ b/bindings/lua/rs232.lua
@@ -187,7 +187,7 @@ function Port:open()
   if not ok then
     self._p:close()
 	self._p = nil
-    return nil, err
+    return nil, ret
   end
 
   return self, tostring(self._p)

--- a/bindings/lua/rs232.lua
+++ b/bindings/lua/rs232.lua
@@ -294,9 +294,10 @@ function Port:device(...)
 end
 
 function Port:fd(...)
-  local ok, fd = F(self._p:fd(...))
-  if not ok then return nil, fd end
-  return fd
+  -- C rs232_fd() returns the bare file descriptor, NOT an (err, value) tuple.
+  -- Running it through F() misreads any nonzero fd as an RS232 error code and
+  -- yields nil -- which silently disables the cooperative (fd-poll) read path.
+  return self._p:fd(...)
 end
 
 local function check_val(value, NAMES, VALUES)

--- a/rockspecs/rs232-scm-0.rockspec
+++ b/rockspecs/rs232-scm-0.rockspec
@@ -18,7 +18,7 @@ description = {
 }
 
 dependencies = {
-  "lua >= 5.1, < 5.4"
+  "lua >= 5.1, <= 5.4"
 }
 
 external_dependencies = {

--- a/rockspecs/rs232-scm-0.rockspec
+++ b/rockspecs/rs232-scm-0.rockspec
@@ -2,13 +2,13 @@ package = "rs232"
 version = "scm-0"
 
 source = {
-  url = "https://github.com/srdgame/librs232/archive/master.zip",
+  url = "https://github.com/flozano/librs232/archive/master.zip",
   dir = "librs232-master",
 }
 
 description = {
   summary    = "Serial port communication library",
-  homepage   = "https://github.com/srdgame/librs232",
+  homepage   = "https://github.com/flozano/librs232",
   license    = "MIT/X11",
   maintainer = "Dirk Chang",
   detailed   = [[


### PR DESCRIPTION
the build seemed to work:

```
rs232 scm-0 depends on lua >= 5.1, <= 5.4 (5.4-1 provided by VM: success)
env MACOSX_DEPLOYMENT_TARGET=11.0 gcc -O2 -fPIC -I/opt/homebrew/opt/lua/include/lua5.4 -c src/rs232.c -o src/rs232.o -DRS232_EXPORT -Iinclude
env MACOSX_DEPLOYMENT_TARGET=11.0 gcc -O2 -fPIC -I/opt/homebrew/opt/lua/include/lua5.4 -c src/rs232_posix.c -o src/rs232_posix.o -DRS232_EXPORT -Iinclude
env MACOSX_DEPLOYMENT_TARGET=11.0 gcc -O2 -fPIC -I/opt/homebrew/opt/lua/include/lua5.4 -c bindings/lua/luars232.c -o bindings/lua/luars232.o -DRS232_EXPORT -Iinclude
env MACOSX_DEPLOYMENT_TARGET=11.0 gcc  -bundle -undefined dynamic_lookup -all_load -o /var/folders/c7/3b0ybh1j5hg3fgnj8yy9qwtm0000gn/T/luarocks_build-rs232-scm-0-7252118/rs232/core.so src/rs232.o src/rs232_posix.o bindings/lua/luars232.o
rs232 scm-0 is now installed in /Users/flozano/Projects/lua/myproject/src-lua/lua_modules (license: MIT/X11)
```